### PR TITLE
ignore *.pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.dll
 *.so
 *.pyd
+*.pyc


### PR DESCRIPTION
I upgrade YCM, git status output this:
?? regex_2/_regex_core.pyc
?? regex_2/regex.pyc
?? regex_3/__pycache__/
*.pyc need be ignored.